### PR TITLE
Add async API to conform to Atom's new async git api

### DIFF
--- a/lib/svn-repository.coffee
+++ b/lib/svn-repository.coffee
@@ -29,6 +29,16 @@ class SvnRepository
       null
 
   constructor: (path, options={}) ->
+    fakeAsync = (fn) -> new Promise((resolve) -> setTimeout((-> resolve(fn())), 0))
+    @async =
+      onDidChangeStatus: (cb) => @onDidChangeStatus(cb)
+      onDidChangeStatuses: (cb) => @onDidChangeStatuses(cb)
+      getCachedUpstreamAheadBehindCount: (path) => @getCachedUpstreamAheadBehindCount(path)
+      getShortHead: (path) => fakeAsync(=> @getShortHead())
+      getCachedPathStatus: (path) => fakeAsync(=> @getCachedPathStatus(path))
+      getLineDiffs: (path, text) => fakeAsync(=> @getLineDiffs(path, text))
+      isStatusNew: (status) => fakeAsync(=> @isStatusNew(status))
+
     @emitter = new Emitter
     @subscriptions = new CompositeDisposable
 


### PR DESCRIPTION
Fixes errors with Atom 1.7, as reported in issue #20.

This is a quick fix; the underlying svn file operations are still performed synchronously, but the execution is deferred. The API does not include all methods, only those that seemed to be needed.
