### PR TITLE
Fix: TypeError: Cannot read property 'ahead' of null

### DIFF
--- a/lib/svn-repository.coffee
+++ b/lib/svn-repository.coffee
@@ -213,7 +213,7 @@ class SvnRepository
   # Returns an {Object} with the following keys:
   #   * `ahead`  The {Number} of commits ahead.
   #   * `behind` The {Number} of commits behind.
-  getCachedUpstreamAheadBehindCount: (path) -> null
+  getCachedUpstreamAheadBehindCount: (path) -> {ahead: 0, behind: 0}
 
   # Public: Returns the svn property value specified by the key.
   #


### PR DESCRIPTION
I've been getting an exception in atom when the svn plugin is enabled:

```
TypeError: Cannot read property 'ahead' of null
    at status-bar-git.GitView.updateAheadBehindCount (/usr/share/atom/resources/app.asar/node_modules/status-bar/lib/git-view.js:213:78)
    at status-bar-git.GitView.update (/usr/share/atom/resources/app.asar/node_modules/status-bar/lib/git-view.js:171:12)
    at status-bar-git.GitView.subscribeToActiveItem (/usr/share/atom/resources/app.asar/node_modules/status-bar/lib/git-view.js:81:19)
    at /usr/share/atom/resources/app.asar/node_modules/status-bar/lib/git-view.js:24:24
```

Assuming you're using git-view to show svn information. It calls getCachedUpstreamAheadBehindCount and expects the return value to be an object with 'ahead' and 'behind' attributes, not null.
