### PR TITLE
explicit HEAD revision in `svn cat`

### DIFF
--- a/lib/svn-utils.coffee
+++ b/lib/svn-utils.coffee
@@ -433,7 +433,7 @@ class Repository
   getSvnCat: (svnPath) ->
     params = [
       'cat'
-      svnPath
+      svnPath + '@HEAD'
     ]
     try
       fileContent = @svnCommand(params)


### PR DESCRIPTION
Fix an issue that occurs when the current file path contains an at sign (@).