### PR TITLE
Added getOriginURL method

### DIFF
--- a/lib/svn-repository.coffee
+++ b/lib/svn-repository.coffee
@@ -226,6 +226,12 @@ class SvnRepository
   # * `path` (optional) {String} path in the repository to get this information
   #   for, only needed if the repository has submodules.
   getOriginUrl: (path) -> null
+  
+  # Public: Returns the origin url of the repository (new method).
+  #
+  # * `path` (optional) {String} path in the repository to get this information
+  #   for, only needed if the repository has submodules.
+  getOriginURL: (path) -> null
 
   # Public: Returns the upstream branch for the current HEAD, or null if there
   # is no upstream branch for the current HEAD.


### PR DESCRIPTION
This method seems to be called by Atom 1.30.0 instead of the old `getOriginUrl`